### PR TITLE
fix: specify mininum node version in package.json

### DIFF
--- a/replicate/package.json
+++ b/replicate/package.json
@@ -9,5 +9,8 @@
 		"lint": "npm run lint:js && npm run lint:css",
 		"lint:css": "npx stylelint \"**/*.css\" --config .stylelintrc.json --allow-empty-input --cache",
 		"lint:js": "npx eslint --ext .js,.html,.twigs"
+	},
+	"engines": {
+		"node": ">=14.0.0"
 	}
 }


### PR DESCRIPTION
This is considered a bugfix and not a breaking change, because it already didn't work (or work correctly) on lower versions.

Fixes #3 