### PR TITLE
fix: make scripts more friendly by default for non-Symfony projects

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "eckinox/eckinox-cs",
-    "version": "1.4.3",
+    "version": "1.4.4",
     "description": "A very opinionated CS/linting setup for PHP projects.",
     "type": "eckinox-metapackage",
     "autoload": {

--- a/replicate/DEV/cs/phpstan.sh
+++ b/replicate/DEV/cs/phpstan.sh
@@ -1,4 +1,16 @@
-addedFiles=$(git diff --diff-filter=d --cached --name-only ":!tests")
+BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../.."
+
+# If this is not a Symfony project, auto-remove the Symfony-specific configuration
+if [ ! -d "${BASEDIR}/var/cache" ] && grep -q "var/cache/" "${BASEDIR}/phpstan.neon"; then
+	sed -i -e 's/var\/cache\/dev\/App_KernelDevDebugContainer.xml//g' "${BASEDIR}/phpstan.neon"
+fi
+
+# Ignore test directory if it exists
+if [ -d "${BASEDIR}/tests" ]; then
+	addedFiles=$(git diff --diff-filter=d --cached --name-only ":!tests")
+else
+	addedFiles=$(git diff --diff-filter=d --cached --name-only "${BASEDIR}")
+fi
 
 if [ -z "$addedFiles" ];
 then

--- a/replicate/DEV/cs/twigcs.sh
+++ b/replicate/DEV/cs/twigcs.sh
@@ -1,2 +1,10 @@
-bin/console lint:twig templates
-vendor/friendsoftwig/twigcs/bin/twigcs templates
+BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../.."
+
+if [ -d "${BASEDIR}/templates" ]; then
+	# Lint templates before validating them if possible
+	if [ -f "${BASEDIR}/bin/console" ]; then
+		bin/console lint:twig templates
+	fi
+
+	vendor/friendsoftwig/twigcs/bin/twigcs templates
+fi


### PR DESCRIPTION
Makes CS scripts more friendly by default for non-Symfony projects (ex.: a bundle, or a simple PHP project)